### PR TITLE
마크다운 이미지 가져오기 구현 (#26)

### DIFF
--- a/src/main/java/com/naver/campushackday/contentsproxyblog/entity/ImageType.java
+++ b/src/main/java/com/naver/campushackday/contentsproxyblog/entity/ImageType.java
@@ -1,0 +1,5 @@
+package com.naver.campushackday.contentsproxyblog.entity;
+
+public enum ImageType {
+	JPG, JPEG, PNG
+}

--- a/src/main/java/com/naver/campushackday/contentsproxyblog/service/PostService.java
+++ b/src/main/java/com/naver/campushackday/contentsproxyblog/service/PostService.java
@@ -2,6 +2,7 @@ package com.naver.campushackday.contentsproxyblog.service;
 
 import com.naver.campushackday.contentsproxyblog.component.GithubMarkdownLoader;
 import com.naver.campushackday.contentsproxyblog.component.MarkdownParser;
+import com.naver.campushackday.contentsproxyblog.entity.ImageType;
 import com.naver.campushackday.contentsproxyblog.entity.Post;
 import com.naver.campushackday.contentsproxyblog.exception.NoSuchPostException;
 import com.naver.campushackday.contentsproxyblog.persistence.PostRepository;
@@ -73,7 +74,7 @@ public class PostService {
 	private String convertImagePath(String repoUrl, String markdownText, String imageUrl) {
 		if (isImage(imageUrl)) {
 			if (checkAbsolutePath(imageUrl)) {
-				markdownText = markdownText.replace(imageUrl, repoUrl + "/master" + imageUrl);
+				markdownText = markdownText.replace(imageUrl, repoUrl + "/raw/master" + imageUrl);
 			}
 		}
 		return markdownText;
@@ -84,6 +85,6 @@ public class PostService {
 	}
 
 	private boolean isImage(String imageUrl) {
-		return imageUrl.contains("png") || imageUrl.contains("jpeg") || imageUrl.contains("jpg");
+		return imageUrl.contains(ImageType.PNG.toString()) || imageUrl.contains(ImageType.JPEG.toString()) || imageUrl.contains(ImageType.JPG.toString());
 	}
 }

--- a/src/main/java/com/naver/campushackday/contentsproxyblog/service/PostService.java
+++ b/src/main/java/com/naver/campushackday/contentsproxyblog/service/PostService.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 @Service
 public class PostService {
+
 	private static final String NO_SUCH_POST_EXCEPTION_MESSAGE = "id 에 해당하는 post가 없습니다.";
 
 	private final PostRepository postRepository;

--- a/src/main/java/com/naver/campushackday/contentsproxyblog/util/StringParser.java
+++ b/src/main/java/com/naver/campushackday/contentsproxyblog/util/StringParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 public class StringParser {
 	private static final String URL_SPLITOR = "/blob/master";
 	private static final String IMAGE_URL_REGEX = "(?:!\\[(.*?)\\]\\((.*?)\\))";
+	private static final Pattern IMAGE_URL_PATTERN = Pattern.compile(IMAGE_URL_REGEX);
 
 	public static String[] parseGithubUrl(String url) {
 		return url.split(URL_SPLITOR);
@@ -15,7 +16,7 @@ public class StringParser {
 
 	public static List<String> parseMarkdownImageUrl(String markdownText) {
 		List<String> allMatches = new ArrayList<>();
-		Matcher m = Pattern.compile(IMAGE_URL_REGEX).matcher(markdownText);
+		Matcher m = IMAGE_URL_PATTERN.matcher(markdownText);
 
 		while (m.find()) {
 			String imageTag = m.group();

--- a/src/main/java/com/naver/campushackday/contentsproxyblog/util/StringParser.java
+++ b/src/main/java/com/naver/campushackday/contentsproxyblog/util/StringParser.java
@@ -1,8 +1,28 @@
 package com.naver.campushackday.contentsproxyblog.util;
 
-public class StringParser {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-	public static String[] parseGithubUrl(String url){
-		return url.split("/blob/master");
+public class StringParser {
+	private static final String URL_SPLITOR = "/blob/master";
+	private static final String IMAGE_URL_REGEX = "(?:!\\[(.*?)\\]\\((.*?)\\))";
+
+	public static String[] parseGithubUrl(String url) {
+		return url.split(URL_SPLITOR);
+	}
+
+	public static List<String> parseMarkdownImageUrl(String markdownText) {
+		List<String> allMatches = new ArrayList<>();
+		Matcher m = Pattern.compile(IMAGE_URL_REGEX).matcher(markdownText);
+
+		while (m.find()) {
+			String imageTag = m.group();
+			String imageUrl = imageTag.substring(imageTag.indexOf("(") + 1, imageTag.length() - 1);
+			allMatches.add(imageUrl);
+		}
+
+		return allMatches;
 	}
 }

--- a/src/test/java/com/naver/campushackday/contentsproxyblog/util/StringParserTest.java
+++ b/src/test/java/com/naver/campushackday/contentsproxyblog/util/StringParserTest.java
@@ -2,6 +2,8 @@ package com.naver.campushackday.contentsproxyblog.util;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -12,5 +14,11 @@ public class StringParserTest {
 		String[] urlElements = StringParser.parseGithubUrl("https://github.com/naver/pinpoint/blob/master/.github/ISSUE_TEMPLATE/bug_report.md");
 		assertThat(urlElements[0], is("https://github.com/naver/pinpoint"));
 		assertThat(urlElements[1], is("/.github/ISSUE_TEMPLATE/bug_report.md"));
+	}
+
+	@Test
+	public void parseMarkdownImageUrl_TEST() {
+		List<String> imageUrls = StringParser.parseMarkdownImageUrl("![sisi](/fdafdaf/fdafd/fad) fdaf  ![](/fdaf/fda)");
+		assertThat(imageUrls.get(1), is("/fdaf/fda"));
 	}
 }


### PR DESCRIPTION
### 구현 방식
* 상대경로와 절대경로로 구분지을 수 있다. 절대경로는 딱히 손대지 않아도 이미지를 가져온다.
* 상대경로는 repoUrl을 앞에 붙여주고 blob/master과 해당 image의 경로를 넣어주어야한다.
* regex를 사용하여 이미지 상대경로를 추출해내서 url을 재조합한다.
### 어려웠던 사항
* 경로를 제대로 입력했지만 이미지가 뜨지 않는 현상이 발생했다.
* 원인은 github.com/~~~~/~~.png 이런식으로 접근하면 github 페이지가 나오는 것이지 해당 이미지 데이터에 접근하는 것이 아니다.
* 해당 이미지 데이터에 접근하기 위해 download 버튼을 누르니까 github.com이 아니라raw.githubusercontent.com 이고 blob이 없어서 바꾸어주었다.